### PR TITLE
Map Control mode right-click to Android Back

### DIFF
--- a/editor-vscode/package.json
+++ b/editor-vscode/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/r2-studio/robotmon-desktop/editor-vscode",
   "description": "Robotmon developing tool with VSCode",
   "publisher": "Robotmon",
-  "version": "1.8.8",
+  "version": "1.8.9-rc.1",
   "icon": "res/logo.png",
   "engines": {
     "vscode": "^1.57.0"

--- a/editor-vscode/package.json
+++ b/editor-vscode/package.json
@@ -7,7 +7,7 @@
   "version": "1.8.9-rc.1",
   "icon": "res/logo.png",
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.63.0"
   },
   "categories": [
     "Other"
@@ -352,7 +352,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "14.x",
-    "@types/vscode": "^1.57.0",
+    "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "eslint": "^7.27.0",

--- a/editor-vscode/package.json
+++ b/editor-vscode/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/r2-studio/robotmon-desktop/editor-vscode",
   "description": "Robotmon developing tool with VSCode",
   "publisher": "Robotmon",
-  "version": "1.8.9-rc.1",
+  "version": "1.8.9",
   "icon": "res/logo.png",
   "engines": {
     "vscode": "^1.63.0"

--- a/editor-vscode/res/html/screenUtilsPanel.html
+++ b/editor-vscode/res/html/screenUtilsPanel.html
@@ -112,7 +112,7 @@
       </div>
       <!-- <div style="height: 40px;"></div> -->
       <div id="preview" style="padding-top: 76px;">
-        <div id="screenImageContainer">
+        <div id="screenImageContainer" data-vscode-context='{"preventDefaultContextMenuItems": true}'>
           <img id="screenImage" draggable="false"/>
           <div id="positionCol"></div>
           <div id="positionRow"></div>
@@ -167,6 +167,13 @@
           mouseMode = $(this).val();
         });
         // preview
+        $("#screenImageContainer").on('contextmenu', (e) => {
+          e.preventDefault();
+          if (mouseMode == 'controlMode') {
+            vscode.postMessage({command: 'back'});
+          }
+          return false;
+        });
         $("#screenImageContainer").mousemove((e) => {
           const x = Math.floor(e.offsetX / imageWidth * deviceWidth);
           const y = Math.floor(e.offsetY / imageHeight * deviceHeight);
@@ -183,6 +190,9 @@
           }
         });
         $("#screenImageContainer").mousedown((e) => {
+          if (mouseMode == 'controlMode' && e.button === 2) {
+            return;
+          }
           isMouseDown = true;
           if (mouseMode == 'colorMode') {
             vscode.postMessage({command: 'printInfo', x: +posX, y: +posY});
@@ -199,6 +209,9 @@
           }
         });
         $("#screenImageContainer").mouseup((e) => {
+          if (mouseMode == 'controlMode' && e.button === 2) {
+            return;
+          }
           isMouseDown = false;
           if (mouseMode == 'colorMode') {
             // DO NOTHING

--- a/editor-vscode/src/grpc/grpc.proto
+++ b/editor-vscode/src/grpc/grpc.proto
@@ -49,6 +49,7 @@ service GrpcService {
   rpc TapDown(RequestTap) returns (Response) {}
   rpc MoveTo(RequestTap) returns (Response) {}
   rpc TapUp(RequestTap) returns (Response) {}
+  // Future: rpc Keycode(RequestKeycode) returns (Response) {} for pressBack without RunScriptAsync
   rpc Pause(Empty) returns (Response) {}
   rpc Resume(Empty) returns (Response) {}
   rpc Reset(Empty) returns (Response) {}

--- a/editor-vscode/src/remoteDevice.ts
+++ b/editor-vscode/src/remoteDevice.ts
@@ -220,6 +220,13 @@ export class RemoteDevice extends vscode.TreeItem {
     });
   }
 
+  // Workaround: no Keycode gRPC yet. Device already supports key injection via
+  // driver.KeyCode (Java Main2.keyCode → injectInputEvent). To migrate to native gRPC:
+  // 1. service-v2/rpc/grpc.proto — add RequestKeycode { label, during } and rpc Keycode
+  // 2. service-v2/core/api.go — add KeyCode(label string) calling r.driver.KeyCode(label)
+  // 3. service-v2/rpc/grpc_impl.go — implement GRPCServer.Keycode
+  // 4. Rebuild Android service (gomobile) and sync proto to editor-vscode + simple-manager
+  // 5. Run editor-vscode/src/grpc/gen.sh, then replace runScriptAsync below with grpc.invoke(Keycode)
   public pressBack(during: number = 10) {
     return this.runScriptAsync(`keycode('BACK', ${during});`);
   }

--- a/editor-vscode/src/remoteDevice.ts
+++ b/editor-vscode/src/remoteDevice.ts
@@ -220,6 +220,10 @@ export class RemoteDevice extends vscode.TreeItem {
     });
   }
 
+  public pressBack(during: number = 10) {
+    return this.runScriptAsync(`keycode('BACK', ${during});`);
+  }
+
   public tapUp(x: number, y: number, id: number = 0) {
     return new Promise<void>((resolve, reject) => {
       const request = new pb.RequestTap();

--- a/editor-vscode/src/screenUtilsPanel.ts
+++ b/editor-vscode/src/screenUtilsPanel.ts
@@ -81,6 +81,9 @@ export class ScreenUtilsPanel {
       case 'tapUp':
         this.mDevice.tapUp(message.x, message.y);
         break;
+      case 'back':
+        this.mDevice.pressBack();
+        break;
       case 'printInfo':
         const x = message.x;
         const y = message.y;


### PR DESCRIPTION
## Summary
- In the screen control panel, right-click in Control mode now triggers Android Back via `keycode('BACK', 10)` instead of showing VS Code's Cut/Copy/Paste context menu.
- Suppress the default webview context menu and skip right-button tap events so only left-click performs tap/drag control.

## Test plan
- [x] Connect to a remote device and open the screen control panel
- [x] Select Control mode and verify left-click still taps/drags on the device
- [x] Right-click on the device screen and confirm VS Code context menu no longer appears
- [x] Right-click on the device screen and confirm the device navigates back (e.g. on a sign-in or nested page)